### PR TITLE
修复点击启动服务器不跳转到终端界面的bug

### DIFF
--- a/MCSL2Lib/windowInterface.py
+++ b/MCSL2Lib/windowInterface.py
@@ -621,8 +621,10 @@ class Window(MSFluentWindow):
             )
             w.buttonLayout.addWidget(eulaBtn, 1, Qt.AlignVCenter)
             w.exec()
-        else:
+            firstTry = ServerLauncher().startServer()
+        if firstTry:
             self.switchTo(self.consoleInterface)
+            self.navigationInterface.setCurrentItem(self.consoleInterface.objectName())
             self.consoleInterface.serverOutput.setPlainText("")
             self.serverMemThread = MinecraftServerResMonitorUtil(self)
             self.serverMemThread.memPercent.connect(self.consoleInterface.setMemView)


### PR DESCRIPTION
🐛`switchTo`有时并不会跳转到终端界面

修改如下:
- 使用`setCurrentItem`进行跳转
- 同意`Eula`也将自动启动服务器并且跳转