### PR TITLE
F | 修复地板除浮点数会返回浮点数导致 TypeError 的问题

### DIFF
--- a/MCSL2Lib/windowInterface.py
+++ b/MCSL2Lib/windowInterface.py
@@ -428,7 +428,7 @@ class Window(MSFluentWindow):
 
         desktop = QApplication.desktop().availableGeometry()
         w, h = desktop.width(), desktop.height()
-        self.resize(w // 2, h // 1.5)
+        self.resize(w // 2, int(h // 1.5))
         self.move(w // 2 - self.width() // 2, h // 2 - self.height() // 2)
         self.show()
         QApplication.processEvents()


### PR DESCRIPTION
当地板除的操作数是浮点数时，结果将是一个浮点数，类似这样

```python
>>> 900//1.5
600.0
>>> type(900//1.5)
<class 'float'>
>>>
```

在被修改的代码修改之前会导致以下错误

```python
Traceback (most recent call last):
  File "/data/MCSL2/MCSL2.py", line 71, in <module>
    w = Window()
        ^^^^^^^^
  File "/data/MCSL2/MCSL2Lib/singleton.py", line 23, in GetInstance
    Instances[cls] = cls(*args, **kwargs)
                     ^^^^^^^^^^^^^^^^^^^^
  File "/data/MCSL2/MCSL2Lib/windowInterface.py", line 221, in __init__
    self.initWindow()
  File "/data/MCSL2/MCSL2Lib/windowInterface.py", line 431, in initWindow
    self.resize(w // 2, h // 1.5)
TypeError: arguments did not match any overloaded call:
  resize(self, a0: QSize): argument 1 has unexpected type 'int'
  resize(self, w: int, h: int): argument 2 has unexpected type 'float'
```