### PR TITLE
Fix | pyproject.toml中依赖pyqt5-qt5版本不对

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ dependencies = [
     # qt
     "PyQt5",
     "PyQt-Fluent-Widgets[full]",
-    "pyqt5-qt5==5.15.2",
+    "pyqt5-qt5==5.15.12",
     # 系统信息
     "psutil==5.9.5",
     "loguru==0.7.2",


### PR DESCRIPTION
导致的pip安装错误：
```
ERROR: Could not find a version that satisfies the requirement pyqt5-qt5==5.15.2 (from versions: 5.15.11, 5.15.12, 5.15.13)
ERROR: No matching distribution found for pyqt5-qt5==5.15.2
```