### PR TITLE
Fix | 修复了一个Forge服务器安装失败后弹窗文本的格式转换问题

### DIFF
--- a/MCSL2Lib/Pages/configurePage.py
+++ b/MCSL2Lib/Pages/configurePage.py
@@ -2168,7 +2168,7 @@ class ConfigurePage(QWidget):
             self.installingForgeStateToolTip = None
         else:
             self.installingForgeStateToolTip.setContent(
-                self.tr("怪，安装失败！" + (args if args is not ... else ""))
+                self.tr("怪，安装失败！" + (args if type(args) != tuple else " ".join(map(str, args))))
             )
             self.installingForgeStateToolTip.setState(True)
             self.installingForgeStateToolTip = None


### PR DESCRIPTION
代码中，试图将一个元组转为字符串输出
报错：
`TypeError: can only concatenate str (not "tuple") to str`
代码：
```python
1966 | except Exception as e:
1967 |       self.afterInstallingForge(False, e.args)
1968 |       self.addNewServerRollback()
...
2172 | self.installingForgeStateToolTip.setContent(
2173 |      self.tr("怪，安装失败！" + (args if type(args) != tuple else " ".join(map(str, args))))
2174 |  )
```
此处e.args是个数组！！！
修复并改成了
```python
2171 | self.tr("怪，安装失败！" + (args if type(args) != tuple else " ".join(map(str, args))))
```